### PR TITLE
Add ability to create SSH connection using GPG Keys

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -70,7 +70,6 @@ const yyErrCode = 2
 const yyInitialStackSize = 16
 
 //line parser.go.y:126
-
 type Lexer struct {
 	s      *scanner
 	result *node

--- a/ssh.go
+++ b/ssh.go
@@ -34,7 +34,7 @@ func (ki keyboardInteractive) Challenge(user, instruction string, questions []st
 
 func newSSHConnection(addr, user, password string, key []byte) (SSH, error) {
 	var session *ssh.Session
-	var client  *shh.Client
+	var client  *ssh.Client
 	
 	var err error 
 	if len(password) > 0 {

--- a/ssh.go
+++ b/ssh.go
@@ -3,7 +3,8 @@ package tmsh
 import (
 	"bytes"
 	"io"
-    "golang.org/x/crypto/ssh"
+
+	"golang.org/x/crypto/ssh"
 )
 
 type SSH interface {
@@ -34,14 +35,14 @@ func (ki keyboardInteractive) Challenge(user, instruction string, questions []st
 
 func newSSHConnection(addr, user, password string, key []byte) (SSH, error) {
 	var session *ssh.Session
-	var client  *ssh.Client
-	
-	var err error 
+	var client *ssh.Client
+
+	var err error
 	if len(password) > 0 {
 		session, client, err = newSSHSession(addr, user, password)
 	} else {
 		session, client, err = newSSHKeySession(addr, user, key)
-	} 
+	}
 
 	if err != nil {
 		return nil, err
@@ -106,7 +107,7 @@ func newSSHSession(addr, user, password string) (*ssh.Session, *ssh.Client, erro
 
 	conn, err := ssh.Dial("tcp", addr, config)
 	if err != nil {
-		return nil, nil,  err
+		return nil, nil, err
 	}
 
 	session, err := conn.NewSession()
@@ -117,32 +118,32 @@ func newSSHSession(addr, user, password string) (*ssh.Session, *ssh.Client, erro
 	return session, conn, nil
 }
 
-func newSSHKeySession(addr, user string, key []byte) (*ssh.Session, *ssh.Client,  error) { 
+func newSSHKeySession(addr, user string, key []byte) (*ssh.Session, *ssh.Client, error) {
 
-        signer, err := ssh.ParsePrivateKey(key)
-        if err != nil {
-                return nil, nil, err
-        } 
+	signer, err := ssh.ParsePrivateKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
 
-        config := &ssh.ClientConfig{
-                User: user,
-                Auth: []ssh.AuthMethod {
-                       ssh.PublicKeys(signer),
-                },
-                HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-        }
+	config := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
 
-        conn, err := ssh.Dial("tcp", addr, config)
-        if err != nil {
-                return nil, nil, err
-        }
+	conn, err := ssh.Dial("tcp", addr, config)
+	if err != nil {
+		return nil, nil, err
+	}
 
-        session, err := conn.NewSession()
-        if err != nil {
-                return nil, nil, err
-        }
+	session, err := conn.NewSession()
+	if err != nil {
+		return nil, nil, err
+	}
 
-        return session, conn, nil
+	return session, conn, nil
 }
 
 func (conn *sshConn) Send(cmd string) (int, error) {

--- a/tmsh.go
+++ b/tmsh.go
@@ -16,18 +16,18 @@ type BigIP struct {
 
 // NewKeySession is NewSession plus key handling
 func NewKeySession(host, port, user string, key []byte) (*BigIP, error) {
-       return GenSession(host, port, user, "", key)
+	return GenSession(host, port, user, "", key)
 }
 
 // NewSession sets up new SSH session to BIG-IP TMSH
 func NewSession(host, port, user, password string) (*BigIP, error) {
-	return GenSession(host,port,user,password,[]byte{})
+	return GenSession(host, port, user, password, []byte{})
 }
 
 // GenSession handles either Password or SSH Key based..
 func GenSession(host, port, user, password string, key []byte) (*BigIP, error) {
-    sshconn, err := newSSHConnection(host+":"+port, user, password, key)
-	
+	sshconn, err := newSSHConnection(host+":"+port, user, password, key)
+
 	if err != nil {
 		return nil, err
 	}

--- a/tmsh.go
+++ b/tmsh.go
@@ -21,7 +21,7 @@ func NewKeySession(host, port, user string, key []byte) (*BigIP, error) {
 
 // NewSession sets up new SSH session to BIG-IP TMSH
 func NewSession(host, port, user, password string) (*BigIP, error) {
-	return GenSession(host,post,user,password,[]byte{})
+	return GenSession(host,port,user,password,[]byte{})
 }
 
 // GenSession handles either Password or SSH Key based..

--- a/tmsh.go
+++ b/tmsh.go
@@ -16,7 +16,7 @@ type BigIP struct {
 
 // NewKeySession is NewSession plus key handling
 func NewKeySession(host, port, user string, key []byte) (*BigIP, error) {
-       return NewSession(host, port, user, "", key)
+       return GenSession(host, port, user, "", key)
 }
 
 // NewSession sets up new SSH session to BIG-IP TMSH

--- a/tmsh.go
+++ b/tmsh.go
@@ -14,9 +14,20 @@ type BigIP struct {
 	sshconn SSH
 }
 
+// NewKeySession is NewSession plus key handling
+func NewKeySession(host, port, user string, key []byte) (*BigIP, error) {
+       return NewSession(host, port, user, "", key)
+}
+
 // NewSession sets up new SSH session to BIG-IP TMSH
 func NewSession(host, port, user, password string) (*BigIP, error) {
-	sshconn, err := newSSHConnection(host+":"+port, user, password)
+	return GenSession(host,post,user,password,[]byte{})
+}
+
+// GenSession handles either Password or SSH Key based..
+func GenSession(host, port, user, password string, key []byte) (*BigIP, error) {
+    sshconn, err := newSSHConnection(host+":"+port, user, password, key)
+	
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
THe current SSH connection to the BigIP assume using user/password for authentication.  This PR would allow the use of a SSH GPG Key to authenticate the access.

We also added a fix to a bug where the client connection was not closing when the session was ended.