### PR TITLE
Replace the displayed wrong version with the current tag version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,3 +6,5 @@ builds:
       - linux
     goarch:
       - amd64
+    ldflags:
+      - -s -w -X "github.com/shiftky/go-tmsh/cmd/tmsh/cmd.version={{.Version}}"

--- a/cmd/tmsh/cmd/root.go
+++ b/cmd/tmsh/cmd/root.go
@@ -23,7 +23,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of tmsh-cli command.",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("tmsh %s", version)
+		fmt.Printf("tmsh %s\n", version)
 	},
 }
 

--- a/cmd/tmsh/cmd/root.go
+++ b/cmd/tmsh/cmd/root.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+var (
+	version string
+)
+
 var RootCmd = &cobra.Command{
 	Use: "tmsh",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -19,7 +23,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of tmsh-cli command.",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("tmsh v0.2.0")
+		fmt.Printf("tmsh %s", version)
 	},
 }
 


### PR DESCRIPTION
#### What this PR does
The version command always displays v0.2.0.
I added the ldflags to .goreleaser.yml, and I tested [my repository](https://github.com/epy0n0ff/goreleaser-test) that work correctly.